### PR TITLE
Remove duplicate class, replace with intended class

### DIFF
--- a/cfonb/parser/common.py
+++ b/cfonb/parser/common.py
@@ -330,8 +330,8 @@ class ParserRCN(Parser):
     ]
 
 
-class ParserRCN(Parser):
-    _code = 'RCN'
+class ParserREF(Parser):
+    _code = 'REF'
     _regex = [
         ('payment_infor_id',    G_ALL, 35),
         ('instruction_id',      G_ALL, 35),


### PR DESCRIPTION
Remove the duplicate `ParserREF` class, replace with the intended class.

Fix #7 (I guess).